### PR TITLE
feat(UI): adjust blur background from black to black transparent color (QA#23)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,7 @@
   --gray-2: #838383;
   --gray-3: #e6e6e6;
   --gray-4: #f4f4f5;
+  --black-overlay:#00000033;
 }
 
 @theme inline {

--- a/src/components/InfoCard/DetailModal.tsx
+++ b/src/components/InfoCard/DetailModal.tsx
@@ -88,7 +88,7 @@ const DetailModal = ({ onClose, type, name, fullData }: DetailModalProps) => {
   return (
     <div>
       <div
-        className="fixed inset-0 z-40 backdrop-blur-sm bg-[#00000033]"
+        className="fixed inset-0 z-40 backdrop-blur-sm bg-[var(--black-overlay)]"
         onClick={onClose}
       />
       <div className="fixed inset-0 z-50 flex items-end pointer-events-none">

--- a/src/components/InfoCard/ReportModal.tsx
+++ b/src/components/InfoCard/ReportModal.tsx
@@ -65,7 +65,7 @@ const ReportModal: React.FC<ReportModalProps> = ({
     <>
       {/* 背景遮罩 */}
       <div
-        className="fixed inset-0 bg-black bg-opacity-50 z-[70] backdrop-blur-sm"
+        className="fixed inset-0 z-[70] bg-[var(--black-overlay)] backdrop-blur-sm"
         onClick={handleClose}
       />
 


### PR DESCRIPTION
# 調整 popup 彈框背景

**頁面：**現場地圖 > 列表 > 查看資訊 > popup 回報問題

**問題：**
 - popup 視窗背景顏色為黑色，與整體 UI（如 Infocard）不一致

**原因：**
 -  CSS 背景顏色設定為 black，導致彈出視窗的遮罩太黑

**調整項目：**
 - 修改 popup window 背景顏色為白色半透明，新增並使用 global CSS 變數以統一樣式設定

**Issue:**
 - 前端 QA list 23：回報問題彈框背景需跟 InfoCard 一致，不是黑底

<img width="491" height="505" alt="image" src="https://github.com/user-attachments/assets/5b34eece-fc97-499c-959b-1868b071df2a" />
